### PR TITLE
Suppression unités inutiles

### DIFF
--- a/css/sseeeedd.css
+++ b/css/sseeeedd.css
@@ -429,43 +429,43 @@ label {
  * @note Nous avons besoin des valeurs de 0 à 2 au minimum.
 */
 .ma0 {
-  margin: 0em;
+  margin: 0;
 }
 
 .mt0 {
-  margin-top: 0em;
+  margin-top: 0;
 }
 
 .mr0 {
-  margin-right: 0em;
+  margin-right: 0;
 }
 
 .mb0 {
-  margin-bottom: 0em;
+  margin-bottom: 0;
 }
 
 .ml0 {
-  margin-left: 0em;
+  margin-left: 0;
 }
 
 .pa0 {
-  padding: 0em;
+  padding: 0;
 }
 
 .pt0 {
-  padding-top: 0em;
+  padding-top: 0;
 }
 
 .pr0 {
-  padding-right: 0em;
+  padding-right: 0;
 }
 
 .pb0 {
-  padding-bottom: 0em;
+  padding-bottom: 0;
 }
 
 .pl0 {
-  padding-left: 0em;
+  padding-left: 0;
 }
 
 .ma1 {


### PR DESCRIPTION
0em => 0.

0em vaut toujours 0, la tête à toto ! :p

Dans le même genre, tu peux écrire .75em au lieu de 0.75em, mais là, je te laisse le choix si tu aimes ou pas ce genre de notation.
